### PR TITLE
Add notification permission request

### DIFF
--- a/app/src/main/java/com/example/plantpal/ActiveRemindersFragment.kt
+++ b/app/src/main/java/com/example/plantpal/ActiveRemindersFragment.kt
@@ -1,0 +1,90 @@
+package com.example.plantpal
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.plantpal.databinding.FragmentActiveRemindersBinding
+import com.example.plantpal.util.WateringReminderScheduler
+import dagger.hilt.android.AndroidEntryPoint
+import java.util.concurrent.TimeUnit
+
+@AndroidEntryPoint
+class ActiveRemindersFragment : Fragment() {
+
+    private var _binding: FragmentActiveRemindersBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: PlantViewModel by viewModels()
+    private lateinit var remindersAdapter: RemindersAdapter
+    private val TAG = "ActiveRemindersFragment"
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentActiveRemindersBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupRecyclerView()
+        observeReminders()
+    }
+
+    private fun setupRecyclerView() {
+        remindersAdapter = RemindersAdapter(
+            onCancelReminder = { plantName ->
+                viewModel.cancelWateringReminder(plantName)
+            }
+        )
+        binding.rvReminders.apply {
+            adapter = remindersAdapter
+            layoutManager = LinearLayoutManager(requireContext())
+        }
+    }
+
+    private fun observeReminders() {
+        viewModel.activeReminders.observe(viewLifecycleOwner) { workInfos ->
+            Log.d(TAG, "Received ${workInfos.size} workInfos")
+
+            val reminders = workInfos.mapNotNull { workInfo ->
+                val frequency = workInfo.tags.firstOrNull {
+                    it == "frequent" || it == "average" || it == "minimum"
+                } ?: "average"
+
+                val plantName = workInfo.tags.firstOrNull {
+                    it != "frequent" && it != "average" && it != "minimum" && it != "watering_reminder"
+                } ?: return@mapNotNull null
+
+                val nextWateringDate = System.currentTimeMillis() + when (frequency) {
+                    "frequent" -> TimeUnit.DAYS.toMillis(WateringReminderScheduler.FREQUENT_DAYS)
+                    "average" -> TimeUnit.DAYS.toMillis(WateringReminderScheduler.AVERAGE_DAYS)
+                    "minimum" -> TimeUnit.DAYS.toMillis(WateringReminderScheduler.MINIMUM_DAYS)
+                    else -> TimeUnit.DAYS.toMillis(WateringReminderScheduler.DEFAULT_DAYS)
+                }
+
+                Log.d(TAG, "Parsed reminder: Plant=$plantName, Frequency=$frequency, Next=$nextWateringDate")
+
+                WateringReminder(
+                    plantName = plantName,
+                    wateringFrequency = frequency,
+                    nextWateringDate = nextWateringDate
+                )
+            }
+
+            remindersAdapter.submitList(reminders)
+            binding.tvNoReminders.visibility = if (reminders.isEmpty()) View.VISIBLE else View.GONE
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+} 

--- a/app/src/main/java/com/example/plantpal/MainActivity.kt
+++ b/app/src/main/java/com/example/plantpal/MainActivity.kt
@@ -1,17 +1,50 @@
 package com.example.plantpal
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
+    private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
+
+    private fun registerPermissionLauncher() {
+        requestPermissionLauncher =
+            registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+                if (!isGranted) {
+                    Toast.makeText(this, R.string.notification_permission_denied, Toast.LENGTH_SHORT).show()
+                }
+            }
+    }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
+
+        registerPermissionLauncher()
+        requestNotificationPermission()
 
     }
 }

--- a/app/src/main/java/com/example/plantpal/PlantListFragment.kt
+++ b/app/src/main/java/com/example/plantpal/PlantListFragment.kt
@@ -41,6 +41,12 @@ class PlantListFragment : Fragment() {
             findNavController().navigate(action)
         }
 
+        binding.btnViewReminders.setOnClickListener {
+            val action = PlantListFragmentDirections
+                .actionPlantListFragmentToActiveRemindersFragment()
+            findNavController().navigate(action)
+        }
+
         binding.ivAppLogo.setOnClickListener{
             findNavController().navigateUp()
         }

--- a/app/src/main/res/layout/fragment_active_reminders.xml
+++ b/app/src/main/res/layout/fragment_active_reminders.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/backgroundLight"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvRemindersTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/active_reminders_title"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:textColor="@color/greenPrimary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvReminders"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/tvRemindersTitle"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <TextView
+        android:id="@+id/tvNoReminders"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No active reminders"
+        android:textSize="18sp"
+        android:textColor="@color/greenPrimary"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout> 

--- a/app/src/main/res/layout/fragment_plant_list.xml
+++ b/app/src/main/res/layout/fragment_plant_list.xml
@@ -35,6 +35,18 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/ivAppLogo" />
 
+        <Button
+            android:id="@+id/btnViewReminders"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="24dp"
+            android:backgroundTint="@color/greenPrimary"
+            android:text="@string/view_active_reminders"
+            android:textColor="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/addButton" />
+
         <View
             android:id="@+id/view"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/item_reminder.xml
+++ b/app/src/main/res/layout/item_reminder.xml
@@ -45,7 +45,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:layout_marginTop="8dp"
-            android:text="Cancel Reminder"
+            android:text="@string/cancel_reminder"
             android:textColor="@color/white"
             android:backgroundTint="@color/greenPrimary"/>
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -62,6 +62,10 @@
             app:exitAnim="@anim/to_left"
             app:popEnterAnim="@anim/from_left"
             app:popExitAnim="@anim/to_right" />
+
+        <action
+            android:id="@+id/action_plantListFragment_to_activeRemindersFragment"
+            app:destination="@id/activeRemindersFragment" />
     </fragment>
 
     <fragment
@@ -97,6 +101,12 @@
             app:popExitAnim="@anim/to_left"
             app:popUpTo="@id/plantListFragment" />
     </fragment>
+
+    <fragment
+        android:id="@+id/activeRemindersFragment"
+        android:name="com.example.plantpal.ActiveRemindersFragment"
+        android:label="Active Reminders"
+        tools:layout="@layout/fragment_active_reminders" />
 
     <activity
         android:id="@+id/mainActivity"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,12 @@
     <string name="notification_channel_description">Notifications for plant watering reminders</string>
     <string name="notification_title">Time to Water Your Plant!</string>
     <string name="notification_text">Don\'t forget to water your %1$s</string>
+    <string name="notification_permission_denied">Notification permission denied</string>
+
+    <!-- Reminders -->
+    <string name="active_reminders_title">Active Watering Reminders</string>
+    <string name="view_active_reminders">View Reminders</string>
+    <string name="cancel_reminder">Cancel Reminder</string>
     
     <!-- Reminder Frequency Strings -->
     <string name="frequency_frequent">Every 2 days</string>


### PR DESCRIPTION
## Summary
- register ActivityResultLauncher for post-notification permission
- request notification permission at runtime for Android 13+
- show toast when permission denied
- add missing string resource
- create ActiveRemindersFragment for viewing watering reminders
- add button on PlantList screen to open reminders

## Testing
- `sh gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841904d48088328af0215cfa6d601e0